### PR TITLE
Introduce layered SlotMachine architecture

### DIFF
--- a/src/components/SlotMachine/index.ts
+++ b/src/components/SlotMachine/index.ts
@@ -1,24 +1,37 @@
-import type { Application, Container } from 'pixi.js';
-import { Container as PixiContainer, Sprite as PixiSprite, Texture } from 'pixi.js';
-import { gsap } from 'gsap';
+import type { Application, Container as PixiContainer } from 'pixi.js';
+import { Container } from 'pixi.js';
+import { Background } from './layers/Background';
+import { ReelsFrame } from './layers/ReelsFrame';
+import { Reels } from './layers/Reels';
+import { UILayer } from './layers/UILayer';
 
 export class SlotMachine {
-  public container: Container;
+  public container = new Container();
 
-  constructor(private app: Application) {
-    this.container = new PixiContainer();
-  }
+  private bgLayer = new Background();
+  private frameLayer = new ReelsFrame();
+  private reelsLayer = new Reels();
+  private fxLayer = new Container();
+  private uiLayer = new UILayer();
+
+  constructor(private app: Application) {}
 
   async init() {
-   const tex = Texture.WHITE;
-     const centerSquare = new PixiSprite(tex);
-    centerSquare.tint  = 0xffd700;      // zlatna boja (promeni po želji)
-    centerSquare.width = centerSquare.height = 120;
+    await Promise.all([
+      this.bgLayer.init(this.app),
+      this.frameLayer.init(this.app),
+      this.reelsLayer.init(this.app),
+      this.uiLayer.init(this.app),
+    ]);
 
-    // Izračunaj centar render-platna
-    const { width, height } = this.app.renderer;
-    centerSquare.x = (width  - centerSquare.width)  * 0.5;
-    centerSquare.y = (height - centerSquare.height) * 0.5;
-    this.container.addChild(centerSquare);
+    this.container.addChild(
+      this.bgLayer.container,
+      this.frameLayer.container,
+      this.reelsLayer.container,
+      this.fxLayer,
+      this.uiLayer.container
+    );
+
+    this.app.on('spin', () => this.reelsLayer.spin());
   }
 }

--- a/src/components/SlotMachine/layers/Background.ts
+++ b/src/components/SlotMachine/layers/Background.ts
@@ -1,0 +1,17 @@
+import { Container, Sprite, Texture } from 'pixi.js';
+
+export class Background {
+  public container = new Container();
+
+  async init(app: PIXI.Application) {
+    // placeholder texture - solid color
+    const tex = Texture.WHITE;
+    const bg = new Sprite(tex);
+    bg.tint = 0x003366; // dark blue
+
+    bg.width = app.renderer.width;
+    bg.height = app.renderer.height;
+
+    this.container.addChild(bg);
+  }
+}

--- a/src/components/SlotMachine/layers/Reels.ts
+++ b/src/components/SlotMachine/layers/Reels.ts
@@ -1,0 +1,25 @@
+import { Container } from 'pixi.js';
+import { Reel } from '../reel/Reel';
+
+export class Reels {
+  public container = new Container();
+  private reelComponents: Reel[] = [];
+
+  async init(app: PIXI.Application) {
+    const reelCount = 3;
+    for (let i = 0; i < reelCount; i++) {
+      const r = new Reel(i);
+      await r.init(app);
+      r.container.x = i * 160;
+      this.container.addChild(r.container);
+      this.reelComponents.push(r);
+    }
+    // center container
+    this.container.x = (app.renderer.width - (reelCount - 1) * 160) * 0.5;
+    this.container.y = (app.renderer.height - 300) * 0.5;
+  }
+
+  spin() {
+    this.reelComponents.forEach((r) => r.spin());
+  }
+}

--- a/src/components/SlotMachine/layers/ReelsFrame.ts
+++ b/src/components/SlotMachine/layers/ReelsFrame.ts
@@ -1,0 +1,16 @@
+import { Container, Graphics } from 'pixi.js';
+
+export class ReelsFrame {
+  public container = new Container();
+
+  async init(app: PIXI.Application) {
+    const frame = new Graphics();
+    frame.lineStyle(4, 0xffffff);
+    const w = 500;
+    const h = 300;
+    frame.drawRect(0, 0, w, h);
+    frame.x = (app.renderer.width - w) * 0.5;
+    frame.y = (app.renderer.height - h) * 0.5;
+    this.container.addChild(frame);
+  }
+}

--- a/src/components/SlotMachine/layers/UILayer.ts
+++ b/src/components/SlotMachine/layers/UILayer.ts
@@ -1,0 +1,19 @@
+import { Container, Sprite, Texture } from 'pixi.js';
+
+export class UILayer {
+  public container = new Container();
+
+  async init(app: PIXI.Application) {
+    const tex = Texture.WHITE;
+    const btn = new Sprite(tex);
+    btn.tint = 0x00ff00;
+    btn.width = btn.height = 80;
+    btn.anchor.set(0.5);
+    btn.x = app.renderer.width - 100;
+    btn.y = app.renderer.height - 80;
+    btn.interactive = true;
+    btn.buttonMode = true;
+    btn.on('pointertap', () => app.emit('spin'));
+    this.container.addChild(btn);
+  }
+}

--- a/src/components/SlotMachine/reel/Reel.ts
+++ b/src/components/SlotMachine/reel/Reel.ts
@@ -1,0 +1,19 @@
+import { Container, Graphics } from 'pixi.js';
+
+export class Reel {
+  public container = new Container();
+
+  constructor(private index: number) {}
+
+  async init(app: PIXI.Application) {
+    const g = new Graphics();
+    g.beginFill(0xffd700);
+    g.drawRect(0, 0, 140, 280);
+    g.endFill();
+    this.container.addChild(g);
+  }
+
+  spin() {
+    // placeholder spin animation
+  }
+}

--- a/src/components/SlotMachine/reel/Symbol.ts
+++ b/src/components/SlotMachine/reel/Symbol.ts
@@ -1,0 +1,7 @@
+import { Sprite, Texture } from 'pixi.js';
+
+export class Symbol extends Sprite {
+  constructor(tex: Texture) {
+    super(tex);
+  }
+}


### PR DESCRIPTION
## Summary
- add layered structure to SlotMachine (background, frame, reels, FX, UI)
- implement placeholder Reel and Symbol classes
- update index.ts to assemble SlotMachine layers

## Testing
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6852d4665b448320ac974f8703ef11af